### PR TITLE
chore(ci): re-pin supply-chain-guard to v5.2.37 + enable Dependabot

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -1,54 +1,54 @@
 {
   "aahp_version": "3.0",
-  "project": "conduit-vscode",
+  "project": "repo",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1782049283",
-    "timestamp": "2026-06-21T13:41:23Z",
-    "commit": "d94502d",
-    "phase": "fix",
+    "session_id": "cli-1782536877",
+    "timestamp": "2026-06-27T05:07:59Z",
+    "commit": "2577411",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:654db8fd26c44ae262faecd8ab7eb15e2cd984ec7a815d7ba561e7c1b4868e4d",
-      "updated": "2026-06-21T13:41:23Z",
-      "lines": 69,
+      "checksum": "sha256:462c6965581de520228c9ffa2d4869c44d290d01bb5b0c113b9c145b5918bb1a",
+      "updated": "2026-06-27T05:07:41Z",
+      "lines": 71,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:3277e705314a045614999221926914b6a73d71a2d263b0f78859937784c1e615",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-06-27T05:06:39Z",
       "lines": 63,
       "summary": "_Last updated: 2026-03-15_"
     },
     "LOG.md": {
       "checksum": "sha256:7a44a1e0022732bdbb21a1575a7eec807747f9d82da27c54442f292a0310fb76",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-06-27T05:06:39Z",
       "lines": 60,
       "summary": "_Reverse chronological. Latest session first._"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:09f199c1e32b876c6e8e7e699e401abf430a875924f76b4826eb5a7bf0c62b3a",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-06-27T05:06:39Z",
       "lines": 49,
       "summary": "_Quick-glance state for autonomous agents. Last updated: 2026-03-15_"
     },
     "TRUST.md": {
       "checksum": "sha256:b57978939e562fddcf2e4825808b2cab01bd5e50ae919414a2242a5042a936ea",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-06-27T05:06:39Z",
       "lines": 27,
       "summary": "- TypeScript compiles with zero errors"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:daf29e79be137d6d995bc12209360d0258437b5a55878fd00b83c6079f21d309",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-06-27T05:06:39Z",
       "lines": 78,
       "summary": "- TypeScript strict mode, CommonJS output (VS Code extension requirement)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:a4d10594d93378225571f8f0c245677a443c00b73caee9734d67ea45cf601783",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-06-27T05:06:39Z",
       "lines": 49,
       "summary": "(no summary available)"
     }
@@ -56,7 +56,7 @@
   "quick_context": "(no summary available) _Last updated: 2026-03-15_ ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 1447,
-    "full_read": 3528
+    "manifest_plus_core": 1466,
+    "full_read": 3547
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -67,3 +67,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-21 ci: add supply-chain-guard v5.2.35 Action workflow (fail-on critical).
 
 > 2026-06-21 ci(aahp): fix unquoted next_task_id + lint-handoff noreply@ PII exclusion.
+
+> 2026-06-27 ci: re-pin supply-chain-guard Action to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b) and enable Dependabot github-actions weekly updates.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/supply-chain-guard.yml
+++ b/.github/workflows/supply-chain-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: homeofe/supply-chain-guard@89a0f2c97ff866b939b9adf8709d8b431683d937  # v5.2.35
+      - uses: homeofe/supply-chain-guard@be1d718b17cc38e4bce7fa48579b7112e557943b  # v5.2.37
         with:
           fail-on: critical
           comment-on-pr: true


### PR DESCRIPTION
Re-pins the supply-chain-guard action from v5.2.35 (89a0f2c97ff866b939b9adf8709d8b431683d937) to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b), which includes the PR-comment crash fix (no more red Scan), and enables weekly Dependabot github-actions updates.