### PR TITLE
ci: track supply-chain-guard @v5 instead of stale SHA pins

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,18 +2,18 @@
   "aahp_version": "3.0",
   "project": "conduit-vscode",
   "last_session": {
-    "agent": "claude-opus-4-8",
-    "session_id": "cli-1782818277",
-    "timestamp": "2026-06-30T11:17:58Z",
-    "commit": "9f96705",
+    "agent": "claude-fable-5",
+    "session_id": "cli-1783072016",
+    "timestamp": "2026-07-03T09:46:57Z",
+    "commit": "da869bf",
     "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:48eca5c880e0bb6de4df867edbb7d5f69d33784c93ae6394bae8529226208cd3",
-      "updated": "2026-06-30T11:17:56Z",
-      "lines": 79,
+      "checksum": "sha256:28f19e4fdef803c35f17d2212aa96c2f8cc2d7e7c7e3ca90171e39bc84541200",
+      "updated": "2026-07-03T09:46:56Z",
+      "lines": 80,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
@@ -62,7 +62,7 @@
   "quick_context": "(no summary available) _Last updated: 2026-03-15_ ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 1622,
-    "full_read": 3711
+    "manifest_plus_core": 1675,
+    "full_read": 3764
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -77,3 +77,4 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-30 verify: added reviewed expiring PII allowlist, rolled out from AAHP v3.2.0.
 
 > 2026-06-30 ci: exempt Dependabot from the aahp-verify handoff gate (keep supply-chain-guard/codeql/build).
+- 2026-07-03: ci: supply-chain-guard now tracks the moving @v5 release branch instead of a stale SHA pin (owner rule: consumers pin @v5, the release workflow moves it - currently v5.6.1). Ends the recurring stale/broken-pin churn (v5.2.35 crash wave). Config change only.

--- a/.github/workflows/supply-chain-guard.yml
+++ b/.github/workflows/supply-chain-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: homeofe/supply-chain-guard@37cf622e249229d04b49f2ee89068c6e45b28adf  # v5.2.44
+      - uses: homeofe/supply-chain-guard@v5
         with:
           fail-on: critical
           comment-on-pr: true


### PR DESCRIPTION
Owner rule (2026-07-03): consumer repos pin the moving @v5 release branch; the scg release workflow advances it (currently v5.6.1). SHA pins across the estate had drifted onto stale or broken releases (three repos sat on the crashing v5.2.35 this week). Config change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)