### PR TITLE
fix(gate): sync Layer 3 tolerance (WARN on non-ancestor pointer)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,59 +2,59 @@
   "aahp_version": "3.0",
   "project": "conduit-vscode",
   "last_session": {
-    "agent": "claude-fable-5",
-    "session_id": "cli-1783072016",
-    "timestamp": "2026-07-03T09:46:57Z",
-    "commit": "da869bf",
-    "phase": "fix",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1784010324",
+    "timestamp": "2026-07-14T06:25:25Z",
+    "commit": "2a1793d",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:28f19e4fdef803c35f17d2212aa96c2f8cc2d7e7c7e3ca90171e39bc84541200",
-      "updated": "2026-07-03T09:46:56Z",
-      "lines": 80,
+      "checksum": "sha256:baa7e8e7f717d360b59b3c3493923adcb9d2aa7c07d8b38e504057b44681ea8f",
+      "updated": "2026-07-14T06:25:24Z",
+      "lines": 82,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:3277e705314a045614999221926914b6a73d71a2d263b0f78859937784c1e615",
-      "updated": "2026-06-28T14:03:44Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 63,
       "summary": "_Last updated: 2026-03-15_"
     },
     "LOG.md": {
       "checksum": "sha256:7a44a1e0022732bdbb21a1575a7eec807747f9d82da27c54442f292a0310fb76",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 60,
       "summary": "_Reverse chronological. Latest session first._"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:09f199c1e32b876c6e8e7e699e401abf430a875924f76b4826eb5a7bf0c62b3a",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 49,
       "summary": "_Quick-glance state for autonomous agents. Last updated: 2026-03-15_"
     },
     "TRUST.md": {
       "checksum": "sha256:b57978939e562fddcf2e4825808b2cab01bd5e50ae919414a2242a5042a936ea",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 27,
       "summary": "- TypeScript compiles with zero errors"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:daf29e79be137d6d995bc12209360d0258437b5a55878fd00b83c6079f21d309",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 78,
       "summary": "- TypeScript strict mode, CommonJS output (VS Code extension requirement)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:a4d10594d93378225571f8f0c245677a443c00b73caee9734d67ea45cf601783",
-      "updated": "2026-05-05T16:10:19Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-30T08:33:41Z",
+      "updated": "2026-07-14T06:25:24Z",
       "lines": 4,
       "summary": "{"
     }
@@ -62,7 +62,7 @@
   "quick_context": "(no summary available) _Last updated: 2026-03-15_ ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 1675,
-    "full_read": 3764
+    "manifest_plus_core": 1731,
+    "full_read": 3820
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
+
 # STATUS - conduit-vscode
 
 ## Current Version: 0.3.0 (GitHub only - not yet on VS Code Marketplace)

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -231,8 +231,7 @@ if [ "$LEVEL" != "precommit" ]; then
             # Layer 2 already enforced that. Here we just inform.
             log_warn "MANIFEST commit ($MANIFEST_COMMIT) is behind HEAD ($HEAD_SHORT). Run /handoff if code changed."
         else
-            log_fail "MANIFEST commit ($MANIFEST_COMMIT) is not an ancestor of HEAD ($HEAD_SHORT). Stale manifest. Run /handoff."
-            FAILURES=$((FAILURES + 1))
+            log_warn "MANIFEST commit ($MANIFEST_COMMIT) is not an ancestor of HEAD ($HEAD_SHORT). A squash-merge or rebase-merge orphans the branch-local pointer; Layers 1-2 gate real staleness. Run /handoff if code changed."
         fi
     fi
 fi


### PR DESCRIPTION
Syncs the canonical Layer 3 tolerance fix from [homeofe/improvements#12](https://github.com/homeofe/improvements/pull/12). `verify-handoff.sh` Layer 3 now downgrades a non-ancestor `MANIFEST.last_session.commit` from FAIL to WARN, so a squash-merge or rebase-merge no longer trips `AAHP Verify` on main. Layers 1-2 keep gating real staleness; the missing-MANIFEST hard-fail is unchanged. Manifest regenerated against the base commit. Verified locally: 0 checksum mismatches, bash -n clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>