### PR TITLE
docs(handoff): reconcile docs with v0.7.4 reality, close out T-016 and T-006

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -1,27 +1,33 @@
 # DASHBOARD - conduit-vscode
 
-_Quick-glance state for autonomous agents. Last updated: 2026-03-15_
+_Quick-glance state for autonomous agents. Last updated: 2026-07-17_
 
 ## Current State
 
 | Item | Value |
 |---|---|
-| Version | 0.3.0 |
-| Build | passes (`npm run build`, ~123kb) |
-| Tests | 30 passing (`npm test`, vitest) |
-| .vsix packaged | conduit-vscode-0.3.0.vsix (49.56 KB) |
+| Version | 0.7.4 |
+| Build | passes (`npm run build`, ~201kb) |
+| Tests | 314 passing / 1 skipped (`npm test`, vitest, 17 files) |
+| .vsix packaged | conduit-vscode-0.7.4.vsix |
 | Installed locally | elvatis.conduit-vscode |
 | Default proxy | http://127.0.0.1:31338 |
-| Marketplace | not yet (T-006) |
+| Marketplace | dropped by decision 2026-07-17 (no plan to publish; GitHub .vsix only) |
 | GitHub | https://github.com/elvatis/conduit-vscode |
-| Latest release | v0.3.0 |
-| Next task | T-016 - Multi-turn agent loop |
+| Latest release | v0.7.4 |
+| Next task | none - backlog clear |
 
-## Features (v0.3.0)
+## Features (v0.7.4)
 
 | Feature | Status |
 |---|---|
 | Chat Panel | Done |
+| Multi-turn Agent Loop (tool calls, confirmation, error feedback) | Done |
+| Agent Tools (readFile/writeFile/runCommand/searchCode/worktrees) | Done |
+| Agent Backends (Claude CLI, Gemini CLI, Codex, OpenCode, Pi) | Done |
+| Background Agent Sessions (spawn/monitor/kill, persistence, resume) | Done |
+| Git Worktree Isolation | Done |
+| Cost Tracking (per session, budget limits) | Done |
 | Agent Step Cards (collapsible) | Done |
 | Full Markdown Rendering | Done |
 | Chat History Persistence | Done |
@@ -41,8 +47,8 @@ _Quick-glance state for autonomous agents. Last updated: 2026-03-15_
 | Model-Mode Compatibility | Done |
 
 ## Unblocked Tasks (priority order)
-1. **T-016** [high] - Multi-turn agent loop architecture
-2. **T-006** [low] - Marketplace listing
+
+_None. T-016 done (issue #52 closed), T-006 dropped (issue #53 closed)._
 
 ## Related Projects
 - `conduit-bridge` - Playwright-based proxy (must be installed separately)

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -4,6 +4,22 @@ _Reverse chronological. Latest session first._
 
 ---
 
+## Session 4 - 2026-07-17 - Backlog close-out + Dependabot sweep (claude-fable-5)
+
+**Goal:** Merge open Dependabot PRs, resolve the two remaining backlog issues, reconcile stale handoff docs.
+
+**Decisions:**
+- T-006 (Marketplace listing, issue #53) dropped: no plan to publish conduit to the VS Code Marketplace, matching the same-day decision to keep conduit tooling off npm. Distribution stays via GitHub .vsix.
+- T-016 (Multi-turn agent loop, issue #52) was already fully shipped in v0.5.0-v0.7.0 (AgentLoop controller, tool executor, confirmation UI, step cards, error feedback, persistence, cost tracking) - the handoff docs were simply stale at v0.3.0. Verified: 314 tests pass, build clean. Closed as done rather than re-implemented.
+
+**What was done:**
+- Merged Dependabot PRs #62-#66, #69 (setup-node 7, eslint 10.6, vitest 4.1.10, typescript-eslint 8.63, coverage-v8) via sequential rebase queue
+- Closed issues #52 (done) and #53 (dropped)
+- Reconciled STATUS.md, NEXT_ACTIONS.md, DASHBOARD.md, MANIFEST.json task states with the actual v0.7.4 codebase
+- Added `.ai/logs/` to .gitignore
+
+---
+
 ## Session 3 - 2026-03-15 - Agent Steps, Markdown, Codebase Search (claude-opus-4-6)
 
 **Goal:** Fix model selection bug, improve output formatting, add workspace context, agent step UI.

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,67 +2,69 @@
   "aahp_version": "3.0",
   "project": "conduit-vscode",
   "last_session": {
-    "agent": "claude-opus-4-8",
-    "session_id": "cli-1784032793",
-    "timestamp": "2026-07-14T12:39:53Z",
-    "commit": "3412c29",
-    "phase": "fix",
+    "agent": "claude-fable-5",
+    "session_id": "cli-1784305391",
+    "timestamp": "2026-07-17T16:23:11Z",
+    "commit": "3bd19ac",
+    "phase": "documentation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:5235ca0fea61c44cd49aef0c91f6c6ed3fd8b160b39db0044e10307b0aa0c8ff",
-      "updated": "2026-07-14T12:39:36Z",
-      "lines": 84,
+      "checksum": "sha256:4f27c4591d72ca521b46fd74948bbd18ad410ed3c1ee7e166a793c17a5239e4e",
+      "updated": "2026-07-17T16:21:04Z",
+      "lines": 96,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
-      "checksum": "sha256:3277e705314a045614999221926914b6a73d71a2d263b0f78859937784c1e615",
-      "updated": "2026-07-14T12:37:10Z",
-      "lines": 63,
-      "summary": "_Last updated: 2026-03-15_"
+      "checksum": "sha256:a83907ddccb80df5e90c23dd4425887eb005bc4d7f3565cd9898908a070467ff",
+      "updated": "2026-07-17T16:20:30Z",
+      "lines": 58,
+      "summary": "_Last updated: 2026-07-17_"
     },
     "LOG.md": {
-      "checksum": "sha256:7a44a1e0022732bdbb21a1575a7eec807747f9d82da27c54442f292a0310fb76",
-      "updated": "2026-07-14T12:37:10Z",
-      "lines": 60,
+      "checksum": "sha256:9c58f4a3cddf3f2948bef30ec20566bf735b8d0a1afaaf85fb837476df63ff6a",
+      "updated": "2026-07-17T16:21:51Z",
+      "lines": 76,
       "summary": "_Reverse chronological. Latest session first._"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:09f199c1e32b876c6e8e7e699e401abf430a875924f76b4826eb5a7bf0c62b3a",
-      "updated": "2026-07-14T12:37:10Z",
-      "lines": 49,
-      "summary": "_Quick-glance state for autonomous agents. Last updated: 2026-03-15_"
+      "checksum": "sha256:16f3f7f00a0d39667c57dd0d4efbb0d5a6d9d68c01592bec5d8a6a04c00cd38f",
+      "updated": "2026-07-17T16:21:26Z",
+      "lines": 55,
+      "summary": "_Quick-glance state for autonomous agents. Last updated: 2026-07-17_"
     },
     "TRUST.md": {
       "checksum": "sha256:b57978939e562fddcf2e4825808b2cab01bd5e50ae919414a2242a5042a936ea",
-      "updated": "2026-07-14T12:37:10Z",
+      "updated": "2026-05-05T16:10:19Z",
       "lines": 27,
       "summary": "- TypeScript compiles with zero errors"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:daf29e79be137d6d995bc12209360d0258437b5a55878fd00b83c6079f21d309",
-      "updated": "2026-07-14T12:37:10Z",
+      "updated": "2026-05-05T16:10:19Z",
       "lines": 78,
       "summary": "- TypeScript strict mode, CommonJS output (VS Code extension requirement)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:a4d10594d93378225571f8f0c245677a443c00b73caee9734d67ea45cf601783",
-      "updated": "2026-07-14T12:37:10Z",
+      "updated": "2026-05-05T16:10:19Z",
       "lines": 49,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-14T12:37:10Z",
+      "updated": "2026-06-30T08:33:41Z",
       "lines": 4,
       "summary": "{"
     }
   },
-  "quick_context": "(no summary available) _Last updated: 2026-03-15_ ",
+  "quick_context": "(no summary available) _Last updated: 2026-07-17_ ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 1777,
-    "full_read": 3866
+    "manifest_plus_core": 2077,
+    "full_read": 4455
   }
+  ,"next_task_id": "3"
+  ,"tasks": {"T-001":{"title":"[T-006] [low] - VS Code Marketplace listing","status":"dropped","priority":"low","depends_on":[],"created":"2026-07-03T10:12:20.527Z","notes":"**AAHP Task:** `T-006`  \n**Status:** dropped  \n**Priority:** low  \n\nDropped 2026-07-17: no plan to publish to the VS Code Marketplace (matches the decision to keep conduit tooling unpublished). Issue #53 closed.\n\n---\n*Auto-created from AAHP manifest · project: conduit-vscode*","github_issue":53,"github_repo":"elvatis/conduit-vscode"},"T-002":{"title":"[T-016] [high] - Multi-turn agent loop","status":"done","priority":"high","depends_on":[],"created":"2026-07-03T10:12:20.527Z","notes":"**AAHP Task:** `T-016`  \n**Status:** done  \n**Priority:** high  \n\nShipped incrementally in v0.5.0-v0.7.0 (AgentLoop controller, tool execution, confirmation UI, step cards, error feedback, session persistence, cost tracking). Docs reconciled and issue #52 closed 2026-07-17.\n\n---\n*Auto-created from AAHP manifest · project: conduit-vscode*","github_issue":52,"github_repo":"elvatis/conduit-vscode"}}
 }

--- a/.ai/handoff/NEXT_ACTIONS.md
+++ b/.ai/handoff/NEXT_ACTIONS.md
@@ -1,41 +1,35 @@
 # NEXT_ACTIONS.md - conduit-vscode
 
-_Last updated: 2026-03-15_
+_Last updated: 2026-07-17_
 
 ## Status Summary
 
 | Status  | Count |
 |---------|-------|
-| Done    | 18    |
-| Ready   | 2     |
+| Done    | 19    |
+| Ready   | 0     |
 | Blocked | 0     |
+| Dropped | 1     |
 
 ---
 
 ## Ready - Work These Next
 
-### T-016: [high] - Multi-turn agent loop
-
-- **Goal:** Autonomous agent that can execute multi-step plans with tool use (file read/write, terminal commands), self-correct on errors, and show each step as a visible sub-process bubble.
-- **Architecture needed:**
-  - Agent loop controller (orchestrates multiple model calls)
-  - Tool definitions (readFile, writeFile, runCommand, searchCode)
-  - User confirmation UI for destructive actions
-  - Step status bubbles in the chat (running/done/failed)
-  - Error feedback loop (agent sees errors and retries)
-- **Definition of done:** Agent can autonomously complete a multi-file task with visible progress.
-
-### T-006: [low] - VS Code Marketplace listing
-
-- **Goal:** Public listing on marketplace.visualstudio.com.
-- **Note:** Requires publisher account + review.
-- **Definition of done:** `vsce publish` successful, extension findable on marketplace.
+_No open tasks. The backlog is clear._
 
 ---
 
 ## Blocked
 
 _No blocked tasks._
+
+---
+
+## Dropped
+
+### T-006: [low] - VS Code Marketplace listing (issue #53, closed)
+
+- Dropped 2026-07-17: there is no plan to publish conduit to the VS Code Marketplace. This matches the decision to keep the conduit tooling unpublished (npm publishing for conduit-bridge was removed the same day). Distribution stays via the .vsix from GitHub.
 
 ---
 
@@ -61,3 +55,4 @@ _No blocked tasks._
 | T-018 | Full markdown rendering (headings, lists, blockquotes, etc.) | 2026-03-15 |
 | T-019 | #workspace and #codebase context mentions | 2026-03-15 |
 | T-020 | Agent step cards with collapsible UI | 2026-03-15 |
+| T-016 | Multi-turn agent loop (issue #52) - shipped incrementally in v0.5.0-v0.7.0, docs reconciled 2026-07-17 | 2026-07-17 |

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -4,7 +4,7 @@
 
 # STATUS - conduit-vscode
 
-## Current Version: 0.3.0 (GitHub only - not yet on VS Code Marketplace)
+## Current Version: 0.7.4 (GitHub .vsix only - Marketplace publishing dropped by decision 2026-07-17)
 
 ## Feature Status
 | Feature | Status | Notes |
@@ -36,6 +36,12 @@
 | Auto-start bridge | Done | Starts conduit-bridge on activate if proxy unreachable |
 | Model-Mode Compatibility | Done | Warnings when model doesn't support current mode |
 | Model Switch Handoff | Done | Context summary when switching models mid-conversation |
+| Multi-turn Agent Loop (T-016) | Done | AgentLoop controller: stream -> parse tool calls -> execute -> feed results back; duplicate-call detection, error feedback loop, destructive-action confirmation, abort |
+| Agent Tools | Done | readFile, writeFile, runCommand, searchCode + worktree tools; command/branch args validated, execFile no-shell (CWE-78 hardening) |
+| Agent Backends | Done | Claude CLI, Gemini CLI, OpenAI Codex, OpenCode, Pi; background sessions with spawn/monitor/kill and model failover chain |
+| Git Worktree Isolation | Done | Parallel agent work in isolated worktrees, serialized creation, merge-aware cleanup |
+| Agent Session Persistence | Done | Sessions survive VS Code restarts; Resume/Remove/Clear commands |
+| Cost Tracking | Done | Per-session token/cost tracking, budget limits, per-model cost summary |
 
 ## Architecture
 - Extension activates on VS Code startup (`onStartupFinished`)
@@ -47,14 +53,13 @@
 - Bridge uses Playwright browser automation (Grok, Claude, Gemini, ChatGPT web UIs)
 
 ## Build Status
-- Build: `npm run build` - `dist/extension.js` (~123kb): Done
-- Tests: `npm test` - vitest: Done
+- Build: `npm run build` - `dist/extension.js` (~201kb): Done
+- Tests: `npm test` - vitest, 314 passing / 1 skipped across 17 files: Done
 - .vsix packaging: `npx @vscode/vsce package --no-dependencies`: Done
 
 ## Known Issues / Gaps
-- No marketplace listing yet (T-006)
-- No multi-turn agent loop yet (planned - T-016)
 - Bridge must be rebuilt separately when models change
+- Marketplace listing (T-006): dropped 2026-07-17 - no plan to publish, distribution stays via GitHub .vsix
 
 ## Release History
 | Version | Date | Notes |
@@ -62,6 +67,11 @@
 | 0.1.0 | 2026-03-12 | Initial build - full feature set + BridgeManager |
 | 0.2.0 | 2026-03-14 | Chat history, model selector, health dashboard, auto-start, tests, .vsix |
 | 0.3.0 | 2026-03-15 | Agent step cards, full markdown rendering, #workspace/#codebase, model selection fix |
+| 0.4.0 | 2026-03-15 | Per-provider sessions, streaming metadata, inline chat diff preview |
+| 0.5.0 | 2026-03-16 | Multi-turn agent loop with tool execution (T-016 core), auto model selection, local models, smart fallback |
+| 0.6.0 | 2026-03-18 | Agent backends (Claude/Gemini/Codex/OpenCode/Pi), background sessions, worktree isolation |
+| 0.7.0 | 2026-03-18 | CI + LLM validation workflows, shared backend abstraction, session persistence/resume, cost tracking |
+| 0.7.1-0.7.4 | 2026-03-24 to 2026-05-17 | Windows bridge spawn fix, security dep updates, dev dep major bumps (see README changelog) |
 
 <!-- aahp-gate -->
 _AAHP verify gate: v3.0.2 synced 2026-06-20._
@@ -82,3 +92,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 
 > 2026-06-30 ci: exempt Dependabot from the aahp-verify handoff gate (keep supply-chain-guard/codeql/build).
 - 2026-07-03: ci: supply-chain-guard now tracks the moving @v5 release branch instead of a stale SHA pin (owner rule: consumers pin @v5, the release workflow moves it - currently v5.6.1). Ends the recurring stale/broken-pin churn (v5.2.35 crash wave). Config change only.
+
+> 2026-07-17 docs: reconciled handoff docs with reality - version 0.3.0 -> 0.7.4, T-016 multi-turn agent loop marked done (shipped v0.5.0-v0.7.0, issue #52 closed), T-006 marketplace listing dropped by decision (issue #53 closed), test count 314. Merged Dependabot PRs #62-#66 and #69 the same day. No code changes.

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage/
 *.vsix
 .vscode-test/
 *.js.map
+.ai/logs/


### PR DESCRIPTION
## Summary
- The handoff docs (STATUS, DASHBOARD, NEXT_ACTIONS) were stale at v0.3.0. The multi-turn agent loop (T-016, #52) actually shipped incrementally in v0.5.0-v0.7.0: AgentLoop controller, tool executor, streaming tool-call parser, destructive-action confirmation, step cards, error feedback loop, session persistence and cost tracking. Verified today: 314 tests pass, build clean.
- T-006 Marketplace listing (#53) is dropped by decision (2026-07-17): no plan to publish, distribution stays via the GitHub .vsix. Matches the same-day decision to keep conduit tooling off npm.
- MANIFEST task states synced (T-002 done, T-001 dropped), LOG session 4 added, .ai/logs/ ignored.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)