### PR TITLE
release: v0.7.6

### DIFF
--- a/.ai/handoff/DASHBOARD.md
+++ b/.ai/handoff/DASHBOARD.md
@@ -6,18 +6,18 @@ _Quick-glance state for autonomous agents. Last updated: 2026-07-17_
 
 | Item | Value |
 |---|---|
-| Version | 0.7.5 |
+| Version | 0.7.6 |
 | Build | passes (`npm run build`, ~201kb) |
 | Tests | 314 passing / 1 skipped (`npm test`, vitest, 17 files) |
-| .vsix packaged | conduit-vscode-0.7.5.vsix |
+| .vsix packaged | conduit-vscode-0.7.6.vsix |
 | Installed locally | elvatis.conduit-vscode |
 | Default proxy | http://127.0.0.1:31338 |
 | Marketplace | dropped by decision 2026-07-17 (no plan to publish; GitHub .vsix only) |
 | GitHub | https://github.com/elvatis/conduit-vscode |
-| Latest release | v0.7.5 |
+| Latest release | v0.7.6 |
 | Next task | none - backlog clear |
 
-## Features (v0.7.5)
+## Features (v0.7.6)
 
 | Feature | Status |
 |---|---|

--- a/.ai/handoff/LOG.md
+++ b/.ai/handoff/LOG.md
@@ -18,6 +18,7 @@ _Reverse chronological. Latest session first._
 - Reconciled STATUS.md, NEXT_ACTIONS.md, DASHBOARD.md, MANIFEST.json task states with the actual v0.7.4 codebase
 - Added `.ai/logs/` to .gitignore
 - Cut release v0.7.5: first release since 2026-05-17, ships the June CWE-78 hardening + dep sweep; fixed brace-expansion GHSA-jxxr-4gwj-5jf2 via npm audit fix; re-pinned @types/vscode to ~1.90.0 (vsce packaging vs engines.vscode, the Dependabot 1.120 bump had silently undone the v0.7.4 pin) and added a Dependabot ignore rule for it; packaged and attached conduit-vscode-0.7.5.vsix to the GitHub release
+- Cut release v0.7.6: the v0.7.5 publish triggered a new Dependabot batch (#72-#75). Merged the 3 green dev-dep bumps (ts-eslint plugin 8.64, eslint 10.7, @types/node 26.1.1). Held #73 (typescript 6->7): ts-eslint plugin 8.64 peers on typescript ">=4.8.4 <6.1.0" so TS 7 fails npm install; closed it and added a Dependabot ignore for the typescript major. Cleaned up two merged-but-lingering remote branches (docs/handoff-refresh, release/v0.7.5). Dev-only, dist unchanged; packaged conduit-vscode-0.7.6.vsix.
 
 ---
 

--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,18 +2,18 @@
   "aahp_version": "3.0",
   "project": "conduit-vscode",
   "last_session": {
-    "agent": "claude-fable-5",
-    "session_id": "cli-1784305908",
-    "timestamp": "2026-07-17T16:31:48Z",
-    "commit": "9744c2b",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1784306998",
+    "timestamp": "2026-07-17T16:49:58Z",
+    "commit": "412629b",
     "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:8af9394ae7a6ff4d510d4a164706c0992d4bbb9b08ec61c6d608b72f42b8a729",
-      "updated": "2026-07-17T16:31:40Z",
-      "lines": 99,
+      "checksum": "sha256:5e3e8285d5265e4bb493a578f4cd558d2cdbd8f81a0a560d1031ab97bcc0020e",
+      "updated": "2026-07-17T16:49:31Z",
+      "lines": 102,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
@@ -23,14 +23,14 @@
       "summary": "_Last updated: 2026-07-17_"
     },
     "LOG.md": {
-      "checksum": "sha256:1430bcdf8a94e16c236abb1880a12dc981f6497ff8a36a02fa096d02f7dedef0",
-      "updated": "2026-07-17T16:31:28Z",
-      "lines": 77,
+      "checksum": "sha256:26e65112cd66fc22afef4669fbacd7d455812eb54d860075ce0939a89b8e0788",
+      "updated": "2026-07-17T16:49:49Z",
+      "lines": 78,
       "summary": "_Reverse chronological. Latest session first._"
     },
     "DASHBOARD.md": {
-      "checksum": "sha256:9fb78eef07361eb8a97792d80fa5839c6d4c6305d4428009f21f65bacecc5213",
-      "updated": "2026-07-17T16:31:26Z",
+      "checksum": "sha256:69562a32b563cb1f334c64a23dbb59c531c2e890b5d50d7a2edf0f919329942e",
+      "updated": "2026-07-17T16:49:44Z",
       "lines": 55,
       "summary": "_Quick-glance state for autonomous agents. Last updated: 2026-07-17_"
     },
@@ -62,8 +62,8 @@
   "quick_context": "(no summary available) _Last updated: 2026-07-17_ ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 2198,
-    "full_read": 4650
+    "manifest_plus_core": 2336,
+    "full_read": 4876
   }
   ,"next_task_id": "3"
   ,"tasks": {"T-001":{"title":"[T-006] [low] - VS Code Marketplace listing","status":"dropped","priority":"low","depends_on":[],"created":"2026-07-03T10:12:20.527Z","notes":"**AAHP Task:** `T-006`  \n**Status:** dropped  \n**Priority:** low  \n\nDropped 2026-07-17: no plan to publish to the VS Code Marketplace (matches the decision to keep conduit tooling unpublished). Issue #53 closed.\n\n---\n*Auto-created from AAHP manifest · project: conduit-vscode*","github_issue":53,"github_repo":"elvatis/conduit-vscode"},"T-002":{"title":"[T-016] [high] - Multi-turn agent loop","status":"done","priority":"high","depends_on":[],"created":"2026-07-03T10:12:20.527Z","notes":"**AAHP Task:** `T-016`  \n**Status:** done  \n**Priority:** high  \n\nShipped incrementally in v0.5.0-v0.7.0 (AgentLoop controller, tool execution, confirmation UI, step cards, error feedback, session persistence, cost tracking). Docs reconciled and issue #52 closed 2026-07-17.\n\n---\n*Auto-created from AAHP manifest · project: conduit-vscode*","github_issue":52,"github_repo":"elvatis/conduit-vscode"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -4,7 +4,7 @@
 
 # STATUS - conduit-vscode
 
-## Current Version: 0.7.5 (GitHub .vsix only - Marketplace publishing dropped by decision 2026-07-17)
+## Current Version: 0.7.6 (GitHub .vsix only - Marketplace publishing dropped by decision 2026-07-17)
 
 ## Feature Status
 | Feature | Status | Notes |
@@ -73,6 +73,7 @@
 | 0.7.0 | 2026-03-18 | CI + LLM validation workflows, shared backend abstraction, session persistence/resume, cost tracking |
 | 0.7.1-0.7.4 | 2026-03-24 to 2026-05-17 | Windows bridge spawn fix, security dep updates, dev dep major bumps (see README changelog) |
 | 0.7.5 | 2026-07-17 | CWE-78 hardening in agent tools, brace-expansion GHSA fix, dep sweep, @types/vscode re-pin + Dependabot ignore, CI action bumps, docs reconciliation |
+| 0.7.6 | 2026-07-17 | Dev-dep maintenance: ts-eslint plugin 8.64 / eslint 10.7 / @types/node 26.1.1; held TS 6->7 (toolchain peer conflict) + Dependabot ignore for the typescript major; no runtime change |
 
 <!-- aahp-gate -->
 _AAHP verify gate: v3.0.2 synced 2026-06-20._
@@ -97,3 +98,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-07-17 docs: reconciled handoff docs with reality - version 0.3.0 -> 0.7.4, T-016 multi-turn agent loop marked done (shipped v0.5.0-v0.7.0, issue #52 closed), T-006 marketplace listing dropped by decision (issue #53 closed), test count 314. Merged Dependabot PRs #62-#66 and #69 the same day. No code changes.
 
 > 2026-07-17 release: cut v0.7.5 (first release since 2026-05-17). Ships the 2026-06-28 CWE-78 agent-tool hardening plus the dep sweep. Also: brace-expansion GHSA-jxxr-4gwj-5jf2 fixed via npm audit fix; @types/vscode re-pinned to ~1.90.0 (the Dependabot bump to 1.120 had silently undone the v0.7.4 pin and broke vsce packaging against engines.vscode ^1.90.0) with a Dependabot ignore rule added so it stays pinned; conduit-vscode-0.7.5.vsix packaged and attached to the GitHub release.
+
+> 2026-07-17 release: cut v0.7.6. Publishing v0.7.5 triggered a fresh Dependabot batch (#72-#75); merged the 3 green dev-dep bumps (ts-eslint plugin 8.64, eslint 10.7, @types/node 26.1.1) and released them. Held #73 (typescript 6->7): @typescript-eslint/eslint-plugin@8.64 peers on typescript ">=4.8.4 <6.1.0", so TS 7 (native port) fails npm install (ERESOLVE); added a Dependabot ignore for the typescript major. Also cleaned up two merged-but-lingering remote branches (docs/handoff-refresh from #70, release/v0.7.5 from #71). Dev-only bumps, dist/extension.js unchanged.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,11 @@ updates:
       # package when @types/vscode exceeds the engine minimum. Bump both
       # together deliberately, never via Dependabot.
       - dependency-name: "@types/vscode"
+      # TypeScript 7 (native port) is not supported by @typescript-eslint yet
+      # (peer range typescript ">=4.8.4 <6.1.0"). Un-ignore the major once
+      # typescript-eslint publishes a version whose peer range includes TS 7.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Conduit is a VS Code extension that connects VS Code to any OpenAI-compatible AI
 
 - Publisher: `elvatis`
 - Extension ID: `elvatis.conduit-vscode`
-- Current version: `0.7.5`
+- Current version: `0.7.6`
 
 ## Build & Test
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Connect VS Code to **any AI provider** through a single extension. One chat interface for Grok, Claude, Gemini, ChatGPT, OpenAI Codex, OpenCode, Pi, and local models, powered by [conduit-bridge](https://github.com/elvatis/conduit-bridge).
 
-**Current version:** 0.7.5
+**Current version:** 0.7.6
 
 > **Status:** Active development. All core features implemented and tested (314 tests). Requires conduit-bridge running locally.
 
@@ -48,7 +48,7 @@ Connect VS Code to **any AI provider** through a single extension. One chat inte
 
 **Option A - From .vsix file:**
 ```bash
-code --install-extension conduit-vscode-0.7.5.vsix
+code --install-extension conduit-vscode-0.7.6.vsix
 ```
 Or in VS Code: `Extensions > ... > Install from VSIX...`
 
@@ -58,7 +58,7 @@ git clone https://github.com/elvatis/conduit-vscode
 cd conduit-vscode
 npm install --include=dev
 npx @vscode/vsce package --no-dependencies
-code --install-extension conduit-vscode-0.7.5.vsix
+code --install-extension conduit-vscode-0.7.6.vsix
 ```
 
 ### First Launch
@@ -637,7 +637,7 @@ Two GitHub Actions workflows run automatically:
 ### Package for Distribution
 ```bash
 npx @vscode/vsce package --no-dependencies
-# produces conduit-vscode-0.7.5.vsix
+# produces conduit-vscode-0.7.6.vsix
 ```
 
 ### Project Structure
@@ -711,6 +711,11 @@ Open issues tracking planned features:
 ---
 
 ## Changelog
+
+### v0.7.6 (2026-07-17)
+- Dev deps: `@typescript-eslint/eslint-plugin` ^8.64.0 (aligned with `@typescript-eslint/parser` 8.64.0), `eslint` ^10.7.0, `@types/node` ^26.1.1
+- Held back `typescript` 6 -> 7: `@typescript-eslint/eslint-plugin@8.64` peers on `typescript@">=4.8.4 <6.1.0"`, so the lint toolchain cannot resolve against TS 7 yet; added a Dependabot ignore for the `typescript` major
+- No runtime changes (dev-only bumps; bundled `dist/extension.js` unchanged from v0.7.5)
 
 ### v0.7.5 (2026-07-17)
 - Security: command-injection hardening (CWE-78) in agent tool executors - branch names and command tokens from LLM tool args are validated, all git/shell sinks moved to `execFile`/`execFileSync` with no shell (`toolCreateWorktree`, `toolRunCommand`, `toolRemoveWorktree`, `getBranchStatus`, `batchFixIssues` label validation); 32 regression tests added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to conduit-vscode are documented here.
 
+## [0.7.6] - 2026-07-17
+
+### Changed
+- Dev deps: `@typescript-eslint/eslint-plugin` 8.63.0 -> ^8.64.0 (now aligned with `@typescript-eslint/parser` 8.64.0), `eslint` 10.6.0 -> ^10.7.0, `@types/node` 26.1.0 -> ^26.1.1
+- No runtime changes; dev-only bumps, so the packaged `dist/extension.js` is functionally unchanged from v0.7.5
+
+### Held back
+- `typescript` 6 -> 7 (Dependabot #73, closed): `@typescript-eslint/eslint-plugin@8.64` declares a peer of `typescript@">=4.8.4 <6.1.0"`, so the lint toolchain cannot resolve against the TypeScript 7 native port. Added a Dependabot ignore for the `typescript` major; revisit when typescript-eslint's peer range includes TS 7
+
 ## [0.7.5] - 2026-07-17
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "conduit-vscode",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "conduit-vscode",
-      "version": "0.7.5",
+      "version": "0.7.6",
       "license": "Apache-2.0",
       "dependencies": {
         "@elvatis_com/agent-backends": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "conduit-vscode",
   "displayName": "Conduit — Universal AI Bridge",
   "description": "Connect VS Code to any OpenAI-compatible AI provider: Grok, Claude, Gemini, ChatGPT and more via local proxy.",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "publisher": "elvatis",
   "private": true,
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
Dependency-maintenance release. Publishing v0.7.5 triggered a fresh Dependabot batch (#72-#75); this bundles the three green dev-dep bumps and releases them.

- `@typescript-eslint/eslint-plugin` 8.63.0 -> ^8.64.0 (now aligned with `@typescript-eslint/parser` 8.64.0) - #72
- `eslint` 10.6.0 -> ^10.7.0 - #74
- `@types/node` 26.1.0 -> ^26.1.1 - #75
- Held `typescript` 6 -> 7 (#73, closed): `@typescript-eslint/eslint-plugin@8.64` peers on `typescript@">=4.8.4 <6.1.0"`, so TS 7 (native port) fails `npm install` with ERESOLVE. Added a Dependabot ignore for the `typescript` major; revisit when typescript-eslint supports TS 7.

**No runtime changes** - dev-only bumps, so `dist/extension.js` is byte-identical to v0.7.5 (205,790 bytes). 314 tests pass, build clean, .vsix packaged (11 files / 86 KB, verified clean).

After merge: tag v0.7.6 and publish the GitHub release with the .vsix attached.

Note (separate follow-up, not in this PR): the repo has systemic em-dash usage in `package.json` command titles and many `src/*.ts` strings, which violates the no-em-dashes convention. That is a repo-wide cleanup touching runtime strings and deserves its own PR - deliberately kept out of this dep-maintenance release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)